### PR TITLE
Do not require content-length to be set.

### DIFF
--- a/index.php
+++ b/index.php
@@ -55,9 +55,9 @@ try {
     return;
 }
 
-if (!$result->isSuccess() || !$result->getContentLength()) {
+if (!$result->isSuccess()) {
     error_log(
-        "Error in downloaded pdf, content length: "
+        "Error downloading pdf, content length: "
         . $result->getContentLength() . ", url: $url"
     );
     unlink($inputPath);


### PR DESCRIPTION
...it's not required when transfer-encoding is chunked.