### PR TITLE
Use cropbox when converting pdf:s to images.

### DIFF
--- a/src/ImageService.php
+++ b/src/ImageService.php
@@ -112,7 +112,7 @@ class ImageService
             '/usr/bin/timeout 60s /usr/bin/gs -dQUIET -dSAFER -dBATCH -dNOPAUSE'
             . ' -dNOPROMPT -dMaxBitmap=500000000 -dAlignToPixels=0 -dGridFitTT=2'
             . ' -dTextAlphaBits=4 -dGraphicsAlphaBits=4 -r150 -dFirstPage=1'
-            . ' -dLastPage=1 -sDEVICE=jpeg -o %s %s',
+            . ' -dUseCropBox -dLastPage=1 -sDEVICE=jpeg -o %s %s',
             $outputPath, $inputPath
         );
         exec($gs, $output, $returnVar);

--- a/src/TestConvert.php
+++ b/src/TestConvert.php
@@ -1,0 +1,22 @@
+#!/usr/bin/php
+<?php
+/**
+ * Script for testing PDF-file converting fast without docker setup.
+ * Give input and output paths defined in the echo statement below.
+ */
+if (count($argv) < 3) {
+    echo "Usage: TestConvert.php [PDF file path] [Image file output path]\r\n";
+    exit();
+}
+$inputPath = $argv[1];
+$outputPath = $argv[2];
+
+$gs = sprintf(
+    '/usr/bin/timeout 60s /usr/bin/gs -dQUIET -dSAFER -dBATCH -dNOPAUSE'
+    . ' -dNOPROMPT -dMaxBitmap=500000000 -dAlignToPixels=0 -dGridFitTT=2'
+    . ' -dTextAlphaBits=4 -dGraphicsAlphaBits=4 -r150 -dFirstPage=1 -dUseCropBox'
+    . ' -dLastPage=1 -sDEVICE=jpeg -o %s %s',
+    $outputPath, $inputPath
+);
+exec($gs, $output, $returnVar);
+?>

--- a/src/TestConvert.php
+++ b/src/TestConvert.php
@@ -19,4 +19,4 @@ $gs = sprintf(
     $outputPath, $inputPath
 );
 exec($gs, $output, $returnVar);
-?>
+


### PR DESCRIPTION
Sometimes the images contains huge blank area if checked from mediaBox property.
Adds a small script to test converting without a docker.

Caused by:
https://finna-pre.fi/Record/syke.10138_325360?imgid=1